### PR TITLE
bug fix in FITS table reading

### DIFF
--- a/functions/DATA_AGNfitter.py
+++ b/functions/DATA_AGNfitter.py
@@ -291,5 +291,9 @@ class DATA():
         self.dict_modelfluxes = Modelsdict[z_key]
         self.dictkey_arrays = dicts.dictkey_arrays(self.dict_modelfluxes)
         
+        print 'Filter set contains {:d} bands'.format(len(self.filterdict[0]))
+        m = Modelsdict[z_key]
+        bands = m[0][m[0].keys()[0]][0]
+        print 'Model sets contains {:d} bands'.format(len(bands))
         
         

--- a/functions/DATA_AGNfitter.py
+++ b/functions/DATA_AGNfitter.py
@@ -158,14 +158,14 @@ class DATA_all:
             # check that the flux and error columns exist in the fits table
             # stop running if they don't
             if np.any(np.array([f not in colnames for f in flux_cols])):
-                print 'wavelength columns exist without corresponding flux columns'
-                print wl_cols
-                print flux_cols
+                print 'wavelength columns exist without corresponding flux columns in fits file:'
+                for f in flux_cols:
+                    if f not  in colnames: print f
                 sys.exit(1)
             if np.any(np.array([f not in colnames for f in flux_err_cols])):
-                print 'wavelength columns exist without corresponding flux err columns'
-                print wl_cols
-                print flux_cols
+                print 'wavelength columns exist without corresponding flux err columns in fits file:'
+                for f in flux_err_cols:
+                    if f not  in colnames: print f
                 sys.exit(1)
 
             freq_wl_cat_ALL = \
@@ -290,4 +290,6 @@ class DATA():
         self.filterdict = dicts.filter_dictionaries(filters['Bandset'], self.path, filters)   
         self.dict_modelfluxes = Modelsdict[z_key]
         self.dictkey_arrays = dicts.dictkey_arrays(self.dict_modelfluxes)
+        
+        
         

--- a/functions/DATA_AGNfitter.py
+++ b/functions/DATA_AGNfitter.py
@@ -149,10 +149,24 @@ class DATA_all:
 
             #read all wavelengths, fluxes, fluerrors, flags
             colnames = fitstable.dtype.names
+            # handle the case when the columns are strangley ordered in the fits file (i.e. not band1_wl, band1_f, band1_e, band2_wl, band1_f, band1_f, band2_e, etc)
+            # if only their suffixes are different, sorting them should put them in the same order
             wl_cols = [ c for c in colnames if self.cat['freq/wl_suffix'] in c]
-            flux_cols = [ c for c in colnames if self.cat['flux_suffix'] in c]
-            flux_err_cols = [ c for c in colnames if self.cat['fluxerr_suffix'] in c]
-
+            flux_cols = [ w.replace(self.cat['freq/wl_suffix'], self.cat['flux_suffix']) for w in wl_cols ]
+            flux_err_cols = [ w.replace(self.cat['freq/wl_suffix'], self.cat['fluxerr_suffix']) for w in wl_cols ]
+            
+            # check that the flux and error columns exist in the fits table
+            # stop running if they don't
+            if np.any(np.array([f not in colnames for f in flux_cols])):
+                print 'wavelength columns exist without corresponding flux columns'
+                print wl_cols
+                print flux_cols
+                sys.exit(1)
+            if np.any(np.array([f not in colnames for f in flux_err_cols])):
+                print 'wavelength columns exist without corresponding flux err columns'
+                print wl_cols
+                print flux_cols
+                sys.exit(1)
 
             freq_wl_cat_ALL = \
                 np.array([fitstable[c] for c in wl_cols])* self.cat['freq/wl_unit'] 


### PR DESCRIPTION
fluxes and flux errors aren't correctly read in if these columns are in a different order to the wavelength columns in the fits table