### PR TITLE
Bugfix: update deprecated features in NumPy, Pandas, SciPy, Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Requirements
 * Astropy 
 * emcee
 * ultranest
-* 
+* acor
 
 Installation
 ----------------

--- a/RUN_AGNfitter_multi.py
+++ b/RUN_AGNfitter_multi.py
@@ -29,6 +29,7 @@ import multiprocessing as mp
 import itertools
 import pickle
 import argparse
+import pandas as pd
 
 
 #AGNfitter IMPORTS
@@ -102,7 +103,7 @@ def MAKE_model_dictionary(cat_settings, filters_settings, models_settings, clobb
 
     else: ## If model dictionary exists and you want to reuseit
 
-        mydict = pickle.load(open(modelsdict_name, 'rb'))
+        mydict = pd.read_pickle(open(modelsdict_name, 'rb'))
 
         print ( '________________________')
         print ( 'MODELS DICTIONARY currently in use:')
@@ -190,7 +191,7 @@ def RUN_AGNfitter_onesource_independent( line, data_obj, filtersz, models_settin
         print('Done')
         dictz = str.encode(dictz)  
         with open(dictz, 'rb') as f:
-            zdict = pickle.load(f, encoding='latin1')
+            zdict = pd.read_pickle(f)
         Modelsdictz = zdict
         models.DICTS(filtersz, Modelsdictz)
         P = parspace.Pdict (data, models)
@@ -210,7 +211,7 @@ def RUN_AGNfitter_onesource_independent( line, data_obj, filtersz, models_settin
             else:
                 dictz = str.encode(dictz)
                 with open(dictz, 'rb') as f:
-                    zdict = pickle.load(f, encoding='latin1')
+                    zdict = pd.read_pickle(f)
             
             Modelsdictz = zdict
 
@@ -306,6 +307,7 @@ if __name__ == "__main__":
 
     data_ALL = DATA_all(cat_settings, filters_settings)
     data_ALL.PROPS()
+    nsources = data_ALL.cat['nsources']
 
     ## make sure the output paths exist
     if not os.path.isdir(cat_settings['output_folder']):
@@ -327,7 +329,7 @@ if __name__ == "__main__":
         elif args.sourcenumber >= 0:
             RUN_AGNfitter_onesource_independent(args.sourcenumber, data_ALL, filters_settings, models_settings, mc_settings, clobbermodel=clobbermodel)
         else:
-            for i in range(0, 110, 1):
+            for i in range(0, nsources, 1):
                 RUN_AGNfitter_onesource_independent(i, data_ALL, filters_settings, models_settings, mc_settings, clobbermodel=clobbermodel)
             
     else:
@@ -340,7 +342,7 @@ if __name__ == "__main__":
         elif args.sourcenumber >= 0:
             RUN_AGNfitter_onesource_independent(args.sourcenumber, data_ALL, filters_settings, models_settings, mc_settings, clobbermodel=clobbermodel)
         else:
-            for i in range(0, 110, 1):
+            for i in range(0, nsources, 1):
                 RUN_AGNfitter_onesource_independent(i, data_ALL, filters_settings, models_settings, mc_settings, clobbermodel=clobbermodel)
        
         

--- a/functions/DATA_AGNfitter.py
+++ b/functions/DATA_AGNfitter.py
@@ -51,7 +51,7 @@ class DATA_all:
             ### read catalog columns
             # It's necessary to read redshift as decimal.Decimal object because of the representation as a binary floating point number 
             # (python add digits to some values of z)
-            column = pd.read_csv(self.catalog, delim_whitespace=True, decimal=".", skiprows = 0, converters = {'z':decimal.Decimal}) 
+            column = pd.read_csv(self.catalog, sep='\s+', decimal=".", skiprows = 0, converters = {'z':decimal.Decimal}) 
 
             ### properties
             self.name = column.iloc[:, self.cat['name']]
@@ -100,9 +100,9 @@ class DATA_all:
                     np.array([column.iloc[:, c] for c in self.cat['freq/wl_list']])* self.cat['freq/wl_unit'] 
             
             flux_cat_ALL =\
-                np.array(column.iloc[:, self.cat['flux_list']]).astype(np.float) *self.cat['flux_unit']
+                np.array(column.iloc[:, self.cat['flux_list']]).astype(float) *self.cat['flux_unit']
             fluxerr_cat_ALL = \
-                np.array(column.iloc[:, self.cat['fluxerr_list']]).astype(np.float)*self.cat['flux_unit']
+                np.array(column.iloc[:, self.cat['fluxerr_list']]).astype(float)*self.cat['flux_unit']
             if self.cat['ndflag_bool'] == True: 
                 ndflag_cat_ALL = np.array(column.iloc[:, self.cat['ndflag_list']])
 
@@ -254,9 +254,9 @@ class DATA_all:
                 freq_wl_cat_ALL = \
                                 np.array([fitstable[c] for c in wl_cols])* self.cat['freq/wl_unit'] 
             flux_cat_ALL =\
-                np.array([fitstable[ca] for ca in  flux_cols ]).astype(np.float)*self.cat['flux_unit']
+                np.array([fitstable[ca] for ca in  flux_cols ]).astype(float)*self.cat['flux_unit']
             fluxerr_cat_ALL = \
-                np.array([fitstable[ce] for ce in flux_err_cols ]).astype(np.float)*self.cat['flux_unit']
+                np.array([fitstable[ce] for ce in flux_err_cols ]).astype(float)*self.cat['flux_unit']
             if self.cat['ndflag_bool'] == True: 
                 ndflag_cat_ALL = np.array(fitstable[self.cat['ndflag_list']])
 

--- a/functions/DICTIONARIES_AGNfitter.py
+++ b/functions/DICTIONARIES_AGNfitter.py
@@ -67,7 +67,7 @@ class MODELSDICT:
         self.filters_list = a
 
         if os.path.lexists(filename):
-            self.fo = pickle.load(open(filename, 'rb'))
+            self.fo = pd.read_pickle(open(filename, 'rb'))
             self.filters = self.fo.filternames
             self.filterset_name = self.fo.name
         else:

--- a/functions/DICTIONARIES_AGNfitter.py
+++ b/functions/DICTIONARIES_AGNfitter.py
@@ -18,7 +18,7 @@ import sys,os
 import numpy as np
 from . import MODEL_AGNfitter as model
 from . import FILTERS_AGNfitter as filterpy
-from scipy.integrate  import trapz
+from scipy.integrate  import trapezoid
 from scipy.interpolate import interp1d
 import time
 import pickle 
@@ -467,8 +467,8 @@ def filtering_models( model_nus, model_fluxes, filterdict, z ):
         modelfluxes_at_filterlambdas = mod2filter_interpol(lambdas_filter)
         # Compute the flux ratios, equivalent to the filtered fluxes: 
         # F = int(model)/int(filter)
-        integral_model = trapz(modelfluxes_at_filterlambdas*factors_filter, x= lambdas_filter)
-        integral_filter = trapz(factors_filter, x= lambdas_filter)     
+        integral_model = trapezoid(modelfluxes_at_filterlambdas*factors_filter, x= lambdas_filter)
+        integral_filter = trapezoid(factors_filter, x= lambdas_filter)     
         filtered_modelF_lambda = (integral_model/integral_filter)
 
         # Convert all from lambda, F_lambda  to Fnu and nu    

--- a/functions/FILTERS_AGNfitter.py
+++ b/functions/FILTERS_AGNfitter.py
@@ -22,6 +22,7 @@ import pickle
 from astropy import units as u 
 from astropy.table import Table
 from astropy.io import ascii
+import pandas as pd
 
 
 class FILTER:
@@ -155,7 +156,7 @@ def add_newfilters(filters_objects_all_filename, ADDfilters_dict, path):
 	## Add the user's new filters 
 	else:
 		with open(filters_objects_all_filename, 'rb') as f: ## Get old set of all filters
-			filters_objects_all = pickle.load(f, encoding='latin1')
+			filters_objects_all = pd.read_pickle(f)
 		f.close()
 
 		for i in range(len(ADDfilters_dict['names'])): ## Add the new ones
@@ -201,7 +202,7 @@ def change_filters(path, old_names, new_names):
 	filters_objects_all_filename = path+ 'ALL_FILTERS'
 	## Add the user's new filters 
 	with open(filters_objects_all_filename, 'rb') as f: ## Get old set of all filters
-		filters_objects_all = pickle.load(f, encoding='latin1')
+		filters_objects_all = pd.read_pickle(f)
 	f.close()
 
 	a = open(filters_objects_all_filename, 'wb')
@@ -263,7 +264,7 @@ def create_filtersets(filters_dict, path):
 		add_newfilters(filters_objects_all_filename, ADDfilters_dict, path)	    	
 
 	a=open(filters_objects_all_filename, 'rb')
-	filters_objects_all = pickle.load(a, encoding='latin1')
+	filters_objects_all = pd.read_pickle(a)
 	filterset = FILTER_SET(filters_dict['filterset'], filters_dict, filters_objects_all)
 
 	return filterset

--- a/functions/MODEL_AGNfitter.py
+++ b/functions/MODEL_AGNfitter.py
@@ -75,7 +75,7 @@ def GALAXY(path, modelsettings):
         GALAXYatt_dict = dict()
 
         ## Call object containing all galaxy models     
-        BC03dict = pickle.load(open(path + 'models/GALAXY/BC03_840seds.pickle', 'rb'), encoding='latin1')    
+        BC03dict = pd.read_pickle(open(path + 'models/GALAXY/BC03_840seds.pickle', 'rb'))    
 
         ## specify the sizes of the array of parameter values: Here two parameters
         tau_array = BC03dict['tau-values']
@@ -149,7 +149,7 @@ def GALAXY(path, modelsettings):
         GALAXYatt_dict = dict()
         ## Call object containing all galaxy models     
 
-        BC03dict = pickle.load(open(path + 'models/GALAXY/BC03_seds_metal_medium.pickle', 'rb'), encoding='latin1')    
+        BC03dict = pd.read_pickle(open(path + 'models/GALAXY/BC03_seds_metal_medium.pickle', 'rb'))    
 
         ## specify the sizes of the array of parameter values: Here two parameters
         tau_array = BC03dict['tau-values']
@@ -229,7 +229,7 @@ def GALAXY(path, modelsettings):
         GALAXYatt_dict = dict()
         ## Call object containing all galaxy models     
 
-        BC03dict = pickle.load(open(path + 'models/GALAXY/BC03_metal_rxLARGE.pickle', 'rb'), encoding='latin1')    
+        BC03dict = pd.read_pickle(open(path + 'models/GALAXY/BC03_metal_rxLARGE.pickle', 'rb'))    
 
         ## specify the sizes of the array of parameter values: Here two parameters
         tau_array = BC03dict['tau-values']
@@ -314,7 +314,7 @@ def STARBURST(path, modelsettings):
         STARBURST_LIRdict = dict()
 
         #Call object containing all starburst models     
-        DH02CE01dict = pickle.load(open(path + 'models/STARBURST/DH02_CE01.pickle', 'rb'), encoding='latin1') 
+        DH02CE01dict = pd.read_pickle(open(path + 'models/STARBURST/DH02_CE01.pickle', 'rb')) 
         irlumidx = len(DH02CE01dict['SED'])
 
         #Construct dictionaries 
@@ -549,7 +549,7 @@ def BBB(path, modelsettings, nXRaysdata):
 
         model_functions = [0]
         BBBFdict_4plot = dict()
-        R06dict = pickle.load(open(path + 'models/BBB/R06.pickle', 'rb'), encoding='latin1') 
+        R06dict = pd.read_pickle(open(path + 'models/BBB/R06.pickle', 'rb')) 
         bbb_nu, bbb_Fnu = R06dict['wavelength'], R06dict['SED'].squeeze()
 
         BBB_functions = BBBfunctions()
@@ -650,7 +650,7 @@ def BBB(path, modelsettings, nXRaysdata):
 
         model_functions = [0]
         BBBFdict_4plot = dict()     
-        SN12dict = pickle.load(open(path + 'models/BBB/SN12.pickle', 'rb'), encoding='latin1') 
+        SN12dict = pd.read_pickle(open(path + 'models/BBB/SN12.pickle', 'rb')) 
         Mbh_array = SN12dict['logBHmass-values']
         EddR_array = SN12dict['logEddra-values']   
         _, Mbhidx, EddRidx =  np.shape(SN12dict['SED'])
@@ -770,7 +770,7 @@ def BBB(path, modelsettings, nXRaysdata):
         model_functions = [0]
         BBBFdict_4plot = dict()
         ## Call file containing all galaxy models     
-        KD18dict = pickle.load(open(path + 'models/BBB/KD18.pickle', 'rb'), encoding='latin1')    
+        KD18dict = pd.read_pickle(open(path + 'models/BBB/KD18.pickle', 'rb'))    
         parameters_names =['logBHmass', 'logEddra','EBVbbb']
         parameters_types =['grid', 'grid', 'free']
 
@@ -813,7 +813,7 @@ def BBB(path, modelsettings, nXRaysdata):
         model_functions = [0]
         BBBFdict_4plot = dict()
         ## Call file containing all galaxy models     
-        KD18dict = pickle.load(open(path + 'models/BBB/KD18_warmInd.pickle', 'rb'), encoding='latin1')    
+        KD18dict = pd.read_pickle(open(path + 'models/BBB/KD18_warmInd.pickle', 'rb'))    
         parameters_names =['logBHmass', 'logEddra', 'warmIndex', 'EBVbbb']
         parameters_types =['grid', 'grid', 'grid', 'free']
 
@@ -856,7 +856,7 @@ def BBB(path, modelsettings, nXRaysdata):
 
         model_functions = [0]
         BBBFdict_4plot = dict()
-        THB21dict = pickle.load(open(path + 'models/BBB/THB21.pickle', 'rb'), encoding='latin1') #THB21_new.pickle
+        THB21dict = pd.read_pickle(open(path + 'models/BBB/THB21.pickle', 'rb')) #THB21_new.pickle
         bbb_nu, bbb_Fnu = THB21dict['nu'].values.item(), THB21dict['SED'].values.item()
         BBB_functions = BBBfunctions()
 
@@ -965,7 +965,7 @@ def TORUS(path, modelsettings):
 
         TORUSFdict_4plot  = dict()
         #Call object containing all torus models     
-        S04dict = pickle.load(open(path + 'models/TORUS/S04.pickle', 'rb'), encoding='latin1') 
+        S04dict = pd.read_pickle(open(path + 'models/TORUS/S04.pickle', 'rb')) 
         nhidx=len(S04dict['SED'])
         #Construct dictionaries 
         for nhi in range(nhidx):
@@ -984,7 +984,7 @@ def TORUS(path, modelsettings):
         
         TORUSFdict_4plot  = dict()
 
-        NK0dict = pickle.load(open(path + 'models/TORUS/NK0_mean_1p.pickle', 'rb'), encoding='latin1')  
+        NK0dict = pd.read_pickle(open(path + 'models/TORUS/NK0_mean_1p.pickle', 'rb'))  
         incl_idx=len(NK0dict['SED']) 
         #Construct dictionaries 
         for incl_i in range(incl_idx): 
@@ -1002,7 +1002,7 @@ def TORUS(path, modelsettings):
         # Nenkova model with averaged SEDs for each inclination and openning angle (2 parameters)
         TORUSFdict_4plot  = dict()
 
-        NK0_2Pdict = pickle.load(open(path + 'models/TORUS/NK0_mean_2p.pickle', 'rb'), encoding='latin1')  
+        NK0_2Pdict = pd.read_pickle(open(path + 'models/TORUS/NK0_mean_2p.pickle', 'rb'))  
         
         oa_array = NK0_2Pdict['oa-values'].unique()
         incl_array = NK0_2Pdict['incl-values'].unique()
@@ -1027,7 +1027,7 @@ def TORUS(path, modelsettings):
         # Nenkova model with averaged SEDs for each inclination, openning angle and optical depth (3 parameters)
 
         TORUSFdict_4plot  = dict()
-        NK0_3Pdict = pickle.load(open(path + 'models/TORUS/NK0_mean_3p.pickle', 'rb'), encoding='latin1')  
+        NK0_3Pdict = pd.read_pickle(open(path + 'models/TORUS/NK0_mean_3p.pickle', 'rb'))  
         
         oa_array = NK0_3Pdict['oa-values'].unique()
         incl_array = NK0_3Pdict['incl-values'].unique()
@@ -1055,7 +1055,7 @@ def TORUS(path, modelsettings):
         # SKIRTOR model with averaged SEDs for each inclination (the only parameter)
         TORUSFdict_4plot  = dict()
 
-        SKIRTORMdict = pickle.load(open(path + 'models/TORUS/SKIRTOR_mean_1p.pickle', 'rb'), encoding='latin1')  
+        SKIRTORMdict = pd.read_pickle(open(path + 'models/TORUS/SKIRTOR_mean_1p.pickle', 'rb'))  
         incl_array = SKIRTORMdict['incl-values']
         #Construct dictionaries 
         for incl_i in incl_array: 
@@ -1071,7 +1071,7 @@ def TORUS(path, modelsettings):
         # SKIRTOR model with averaged SEDs for each inclination and openning angle (2 parameters)
         TORUSFdict_4plot  = dict()
 
-        SKIRTORdict = pickle.load(open(path + 'models/TORUS/SKIRTOR_mean_2p.pickle', 'rb'), encoding='latin1')  
+        SKIRTORdict = pd.read_pickle(open(path + 'models/TORUS/SKIRTOR_mean_2p.pickle', 'rb'))  
         
         oa_array = SKIRTORdict['oa-values'].unique()
         incl_array = SKIRTORdict['incl-values'].unique()
@@ -1096,7 +1096,7 @@ def TORUS(path, modelsettings):
         # SKIRTOR model with averaged SEDs for each inclination, openning angle and optical depth (3 parameters)
         TORUSFdict_4plot  = dict()
 
-        SKIRTORdict = pickle.load(open(path + 'models/TORUS/SKIRTOR_mean_3p.pickle', 'rb'), encoding='latin1')  
+        SKIRTORdict = pd.read_pickle(open(path + 'models/TORUS/SKIRTOR_mean_3p.pickle', 'rb'))  
         
         oa_array = SKIRTORdict['oa-values'].unique()
         incl_array = SKIRTORdict['incl-values'].unique()
@@ -1124,7 +1124,7 @@ def TORUS(path, modelsettings):
         # SKIRTOR model with averaged SEDs for each inclination, openning angle, optical depth and index of power law (4 parameters)
         TORUSFdict_4plot  = dict()
 
-        CAT3Ddict = pickle.load(open(path + 'models/TORUS/CAT3D_mean_3p.pickle', 'rb'), encoding='latin1')  
+        CAT3Ddict = pd.read_pickle(open(path + 'models/TORUS/CAT3D_mean_3p.pickle', 'rb'))  
         
         incl_array = CAT3Ddict['incl-values'].unique()
         a_array = CAT3Ddict['a-values'][210: ].unique()  #Value of the 2nd set of 168 SEDs 

--- a/functions/MODEL_AGNfitter.py
+++ b/functions/MODEL_AGNfitter.py
@@ -108,8 +108,8 @@ def GALAXY(path, modelsettings):
                 GALAXYFdict_4plot[str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = \
                                                                                         np.log10(gal_nu), renorm_template('GA',gal_Fnu_red)  
                 GALAXY_SFRdict[str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR 
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu.value[0:len(gal_nus):3], x=gal_nus.value[0:len(gal_nus):3])
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu.value[0:len(gal_nus):3], x=gal_nus.value[0:len(gal_nus):3])
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red, x=gal_nu)
                 gal_att_int = gal_Fnu_int- gal_Fnured_int
                 GALAXYatt_dict[str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int 
 
@@ -134,8 +134,8 @@ def GALAXY(path, modelsettings):
                 GALAXYFdict_4plot[str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = \
                                                                                         np.log10(gal_nu), renorm_template('GA',gal_Fnu_red)  
                 GALAXY_SFRdict[str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR 
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu.value[0:len(gal_nus):3], x=gal_nus.value[0:len(gal_nus):3])
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu.value[0:len(gal_nus):3], x=gal_nus.value[0:len(gal_nus):3])
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red, x=gal_nu)
                 gal_att_int = gal_Fnu_int- gal_Fnured_int
                 GALAXYatt_dict[str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int
 
@@ -185,8 +185,8 @@ def GALAXY(path, modelsettings):
 
                 gal_SFR= BC03dict['SFR'][metali,agei,taui,:,:].squeeze()
                 GALAXY_SFRdict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR         
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red*3.826e33, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red*3.826e33, x=gal_nu)
                 gal_att_int = gal_Fnu_int.value - gal_Fnured_int
                 GALAXYatt_dict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int
 
@@ -213,8 +213,8 @@ def GALAXY(path, modelsettings):
 
                 gal_SFR= BC03dict['SFR'][metali,agei,taui,:,:].squeeze()
                 GALAXY_SFRdict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR         
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red*3.826e33, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red*3.826e33, x=gal_nu)
                 gal_att_int = gal_Fnu_int.value - gal_Fnured_int
                 GALAXYatt_dict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int
 
@@ -265,8 +265,8 @@ def GALAXY(path, modelsettings):
 
                 gal_SFR= BC03dict['SFR'][metali,agei,taui,:,:].squeeze()
                 GALAXY_SFRdict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR         
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red*3.826e33, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red*3.826e33, x=gal_nu)
                 gal_att_int = gal_Fnu_int.value - gal_Fnured_int
                 GALAXYatt_dict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int
 
@@ -293,8 +293,8 @@ def GALAXY(path, modelsettings):
 
                 gal_SFR= BC03dict['SFR'][metali,agei,taui,:,:].squeeze()
                 GALAXY_SFRdict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei]))] = gal_SFR         
-                gal_Fnu_int = scipy.integrate.trapz(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
-                gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red*3.826e33, x=gal_nu)
+                gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu[0:len(gal_nus):3]*3.826e33, x=gal_nu)
+                gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red*3.826e33, x=gal_nu)
                 gal_att_int = gal_Fnu_int.value - gal_Fnured_int
                 GALAXYatt_dict[str(metal_array[metali]),str(tau_array.value[taui]),str(np.log10(age_array.value[agei])), str(ebvgal_array[ebvi])] = gal_att_int
 

--- a/functions/PARAMETERSPACE_AGNfitter.py
+++ b/functions/PARAMETERSPACE_AGNfitter.py
@@ -15,7 +15,7 @@ It contains:
 from __future__ import division
 import numpy as np
 import time
-from collections import Iterable
+from collections.abc import Iterable
 import itertools
 import pickle
 from . import PRIORS_AGNfitter as priors
@@ -276,7 +276,7 @@ def get_best_position(filename, nwalkers, P):
     Npar = len(P['names']) 
     #all saved vectors    
     f = open(filename, 'rb')
-    samples = pickle.load(f)
+    samples = pd.read_pickle(f)
     f.close()
 
     #index for the largest likelihood     

--- a/functions/PLOTandWRITE_AGNfitter.py
+++ b/functions/PLOTandWRITE_AGNfitter.py
@@ -469,7 +469,7 @@ class CHAIN:
                 self.best_fit_pars = self.flatchain.iloc[idx_sorted[0]].values
 
             elif self.mc_settings['sampling_algorithm'] == 'emcee':
-                samples = pickle.load(f, encoding='latin1')
+                samples = pd.read_pickle(f)
                 f.close()
                 self.chain = samples['chain']
                 nwalkers, nsamples, npar = samples['chain'].shape

--- a/functions/PLOTandWRITE_AGNfitter.py
+++ b/functions/PLOTandWRITE_AGNfitter.py
@@ -890,12 +890,12 @@ class FLUXES_ARRAYS:
                     Lnuga = nuLnuga[:,index] / all_nus_rest_int
                     if (out['intlum_models'][m] == 'AGNfrac_rad') or (out['intlum_models'][m] == 'AGNfrac1-10GHz') or (out['intlum_models'][m] == 'AGNfrac10-30GHz') or (out['intlum_models'][m] == 'AGNfrac50-200GHz'):
                         Lnurad = nuLnurad[:,index] / all_nus_rest_int
-                        Lnurad_int = scipy.integrate.trapz(Lnurad, x=all_nus_rest_int)
+                        Lnurad_int = scipy.integrate.trapezoid(Lnurad, x=all_nus_rest_int)
                     Lnubb = nuLnubb[:,index] / all_nus_rest_int
-                    Lnuto_int = scipy.integrate.trapz(Lnuto, x=all_nus_rest_int)
-                    Lnusb_int = scipy.integrate.trapz(Lnusb, x=all_nus_rest_int)
-                    Lnuga_int = scipy.integrate.trapz(Lnuga, x=all_nus_rest_int)
-                    Lnubb_int = scipy.integrate.trapz(Lnubb, x=all_nus_rest_int)
+                    Lnuto_int = scipy.integrate.trapezoid(Lnuto, x=all_nus_rest_int)
+                    Lnusb_int = scipy.integrate.trapezoid(Lnusb, x=all_nus_rest_int)
+                    Lnuga_int = scipy.integrate.trapezoid(Lnuga, x=all_nus_rest_int)
+                    Lnubb_int = scipy.integrate.trapezoid(Lnubb, x=all_nus_rest_int)
 
                     if out['intlum_models'][m] == 'AGNfrac_IR':                
                         AGNfrac = (Lnuto_int)/(Lnuto_int+Lnusb_int) 
@@ -958,7 +958,7 @@ class FLUXES_ARRAYS:
                     index  = ((all_nus_rest >= np.log10(out['intlum_freqranges'][m][1].value)) & (all_nus_rest<= np.log10(out['intlum_freqranges'][m][0].value)))            
                     all_nus_rest_int = 10**(all_nus_rest[index])
                     Lnu = nuLnu[:,index] / all_nus_rest_int
-                    Lnu_int = scipy.integrate.trapz(Lnu, x=all_nus_rest_int)
+                    Lnu_int = scipy.integrate.trapezoid(Lnu, x=all_nus_rest_int)
                     int_lums.append(Lnu_int)
 
         return np.array(int_lums)

--- a/functions/PRIORS_AGNfitter.py
+++ b/functions/PRIORS_AGNfitter.py
@@ -87,8 +87,8 @@ def prior_energy_balance(data, GALAXYatt_dict, GALAXYFdict, gal_obj, GA, STARBUR
         rest_bands = bands + np.log10((1+data.z))                               #Pass to rest frame
         bandsf, Fnuf = f(10**rest_bands, gal_Fnu*1e18, gal_obj.matched_parkeys[-1])  #bandsf not in log form, apply reddening
         gal_nu, gal_Fnu_red = bandsf/(1+data.z), Fnuf                           #Pass to observed frame
-        gal_Fnu_int = scipy.integrate.trapz(gal_Fnu*3.826e33, x=gal_nu)          
-        gal_Fnured_int = scipy.integrate.trapz(gal_Fnu_red*3.826e33, x=gal_nu)
+        gal_Fnu_int = scipy.integrate.trapezoid(gal_Fnu*3.826e33, x=gal_nu)          
+        gal_Fnured_int = scipy.integrate.trapezoid(gal_Fnu_red*3.826e33, x=gal_nu)
         gal_att_int = gal_Fnu_int - gal_Fnured_int
         Lgal_att = abs(gal_att_int * 10**(GA))                                       #Calculate the attenuated luminosity
 


### PR DESCRIPTION
Hi, I have been using Python 3.10, numpy 1.26.4, pandas 2.2.0 to run the code, but get errors due to a few deprecated module/arguments. They are fixed as follows.

1. [`np.float` is deprecated](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) since `numpy 1.20.0`, it's now replaced with `float`.
2. [`pickle.load()` does not work](https://github.com/pandas-dev/pandas/issues/56825) with `pandas 1.4.2` files if `pandas 2.1.4` (and higher) is installed. This is fixed by replacing `pickle.load()` with `pd.read_pickle()`.
3. [The argument `delim_whitespace` of `pd.read_csv()` is deprecated](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas.read_csv) since `pandas 2.2.0`. It's now replaced with `sep="\s+"`.
4. [`Iterable` class from `collections` is deprecated](https://docs.python.org/3.9/library/collections.html) and moved to `collections.abc` since `Python 3.3`.  Now`from collections.abc import Iterable` is used.
5. [`scipy.integrate.trapz` has been removed](https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations) in favor of `trapezoid` since `SciPy 1.14.0`; all occurrences have been updated accordingly.

I also added `acor ` in the list of required packages in the readme file. 